### PR TITLE
Use single quotes inside an f-string enclosed in double quotes

### DIFF
--- a/src/propositional_tactics.py
+++ b/src/propositional_tactics.py
@@ -101,7 +101,7 @@ class SplitGoal(Tactic):
     def activate(self, state: ProofState) -> list[ProofState]:
         conjuncts = get_conjuncts(state.goal)
         if conjuncts is not None:
-            print(f"Split goal into {", ".join([str(conjunct) for conjunct in conjuncts])}")
+            print(f"Split goal into {', '.join([str(conjunct) for conjunct in conjuncts])}")
             new_goals = []
             for conjunct in conjuncts:
                 newstate = state.copy()
@@ -166,7 +166,7 @@ class SplitHyp(Tactic):
             hyp = state.hypotheses[self.h]
             conjuncts = get_conjuncts(hyp)
             if conjuncts is not None:
-                print(f"Splitting {describe(self.h,hyp)} into {", ".join([str(conjunct) for conjunct in conjuncts])}.")
+                print(f"Splitting {describe(self.h,hyp)} into {', '.join([str(conjunct) for conjunct in conjuncts])}.")
                 new_state = state.copy()
                 new_state.remove_hypothesis(self.h)
                 for i, conjunct in enumerate(conjuncts):
@@ -206,7 +206,7 @@ class Cases(Tactic):
             if disjuncts == None:
                 print(f"Unable to split {hyp} into cases.")
                 return [state.copy()]
-            print(f"Splitting {describe(self.h,hyp)} into cases {", ".join([str(disjunct) for disjunct in disjuncts])}.")
+            print(f"Splitting {describe(self.h,hyp)} into cases {', '.join([str(disjunct) for disjunct in disjuncts])}.")
             new_goals = []
             for disjunct in disjuncts:
                 new_state = state.copy()


### PR DESCRIPTION
I get this error when use the original code:

```
>>> from main import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/youhua.li/code/estimates/src/main.py", line 2, in <module>
    from propositional_tactics import *
  File "/Users/youhua.li/code/estimates/src/propositional_tactics.py", line 103
    print(f"Split goal into {", ".join([str(conjunct) for conjunct in conjuncts])}")
                              ^
SyntaxError: f-string: expecting '}'
```

It looks that python interpret this f-string 

```
f"Split goal into {", ".join([str(conjunct) for conjunct in conjuncts])}"
``` 
ending at the first '"": `Split goal into {"`

I am not sure why it works for others, but for me it needs the fix. I tested in both python 3.10 and 3.11. 

