### PR TITLE
Fix typos in propositional_tactics.py

### DIFF
--- a/src/estimates/propositional_tactics.py
+++ b/src/estimates/propositional_tactics.py
@@ -250,7 +250,7 @@ class Cases(Tactic):
 
 class ByCases(Tactic):
     """
-    Split into two cases, depending on whether an assertin is true or false."""
+    Split into two cases, depending on whether an assertion is true or false."""
 
     def __init__(self, statement: Boolean, name: str = "this") -> None:
         self.statement = statement
@@ -292,7 +292,7 @@ class Option(Tactic):
         if disjuncts is None:
             raise ValueError(f"Goal {state.goal} did not split into a disjunction.")
         if self.n > len(disjuncts):
-            raise ValueError(f"Goal {state.goal} only hhad {len(disjuncts)} disjuncts.")
+            raise ValueError(f"Goal {state.goal} only had {len(disjuncts)} disjuncts.")
         print(
             f"Replacing goal {state.goal} with option {self.n}: {disjuncts[self.n - 1]}."
         )


### PR DESCRIPTION
## Fixes

Fixed the following typos in propositional_tactics.py:

1. Changed "hhad" to "had" in the Option class
2. Changed "assertin" to "assertion" in the ByCases class docstring

## Reason for Fix

These typo fixes improve code readability and professionalism.