### PR TITLE
Fix ByCases.__str__ Method to Correct Name Reference Error

### DIFF
--- a/src/estimates/propositional_tactics.py
+++ b/src/estimates/propositional_tactics.py
@@ -276,7 +276,7 @@ class ByCases(Tactic):
         if self.name == "this":
             return "by_cases " + str(self.statement)
         else:
-            return "by_cases " + describe(str.name, self.statement)
+            return "by_cases " + describe(self.name, self.statement)
 
 
 class Option(Tactic):


### PR DESCRIPTION
## Fix ByCases.\_\_str\_\_ Method Error

Fixed the string representation method error in the ByCases class.

### Before Fix:
![Error Before Fix](https://github.com/user-attachments/assets/c43e059c-abaa-4eee-a189-6e9206275990)

### After Fix:
![Result After Fix](https://github.com/user-attachments/assets/387feeec-4050-4e31-b465-4517d8a2ad83)

This fix resolves a runtime error that occurred when using a non-default name.