### PR TITLE
Simplify undo method logic and remove unreachable code

### DIFF
--- a/src/estimates/proofassistant.py
+++ b/src/estimates/proofassistant.py
@@ -375,10 +375,6 @@ class ProofAssistant:
                 self.current_node.tactic = None  # clear the tactic
                 self.current_node.children = []  # clear the children
             else:
-                if self.current_node.parent is not None:
-                    print(f"Undid current tactic ({self.current_node.tactic}).")
-                    self.current_node.tactic = None  # clear the tactic
-                    self.current_node.children = []  # clear the children
                 print("No tactics to undo.")
         else:
             raise ValueError("Cannot undo in assumption mode.")


### PR DESCRIPTION
This PR refactors the undo method in ProofAssistant:

- Removes unreachable and redundant code in the else branch.
- Now only prints "No tactics to undo." when at the root node.
- Only prints the undo message when an actual undo occurs.

No functional changes, only logic simplification.