### PR TITLE
#13 Simplify the goal to the most when checking Boolean hypotheses

### DIFF
--- a/src/estimates/linprog.py
+++ b/src/estimates/linprog.py
@@ -170,23 +170,3 @@ def feasibility(inequalities: list[Inequality]) -> tuple[bool, dict]:
         raise ValueError(
             f"Farkas lemma violation!  Problem is neither feasible nor infeasible. Inequalities: {inequalities}"
         )
-
-
-def verbose_feasibility(inequalities: list[Inequality]) -> bool:
-    """Test via dual linear programming if a list of inequalities is feasible, outputting a certificate in both cases."""
-    print("Checking feasibility of the following inequalities:")
-    for ineq in inequalities:
-        print(ineq)
-
-    outcome, dict = feasibility(inequalities)
-    if outcome:
-        print("Feasible with the following values:")
-        for var, value in dict.items():
-            print(f"{var} = {value}")
-        return True
-    else:
-        print("Infeasible by summing the following:")
-        for ineq, coeff in dict.items():
-            if coeff != Fraction(0, 1):
-                print(f"{ineq} multiplied by {coeff}")
-        return False

--- a/src/estimates/main.py
+++ b/src/estimates/main.py
@@ -62,7 +62,7 @@ def case_split_solution() -> None:
     p = case_split_exercise()
     p.use(Cases("h1"))
     p.use(SimpAll())
-    p.use(SimpAll(repeat=True)) # The second case is non-deterministic, and can require one or more iterations to close
+    p.use(SimpAll())
 
 
 def split_exercise() -> ProofAssistant:

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -115,8 +115,8 @@ def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic
         print(f"Simplified {goal} to False using {hypotheses}.")
         return false
 
-    # TODO: makeSimpliestGoal is recursive also, may be merged with rsimp
-    new_goal = makeSimpliestGoal(new_goal, hypotheses)
+    # TODO: this is recursive also, and may be merged with rsimp
+    new_goal = makeSimplestGoal(new_goal, hypotheses)
 
     new_goal = rsimp(new_goal, hypotheses, use_sympy)
 
@@ -124,7 +124,7 @@ def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic
         print(f"Simplified {goal} to {new_goal} using {hypotheses}.")
     return new_goal
 
-def makeSimpliestGoal(goal, hypotheses):
+def makeSimplestGoal(goal, hypotheses):
     new_goal = goal
     for hyp in hypotheses:
         if isinstance(hyp,Boolean):
@@ -133,7 +133,7 @@ def makeSimpliestGoal(goal, hypotheses):
             if isinstance(hyp, Not):
                 new_goal = new_goal.subs(hyp.args[0], False)
     if new_goal != goal:
-        return makeSimpliestGoal(new_goal, hypotheses)
+        return makeSimplestGoal(new_goal, hypotheses)
     else:
         return goal
 

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -115,12 +115,8 @@ def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic
         print(f"Simplified {goal} to False using {hypotheses}.")
         return false
 
-    for hyp in hypotheses:
-        if isinstance(hyp,Boolean):
-            # If a hypothesis is a boolean, we can use it to simplify the goal further.
-            new_goal = new_goal.subs(hyp, True)
-            if isinstance(hyp, Not):
-                new_goal = new_goal.subs(hyp.args[0], False)
+    # TODO: makeSimpliestGoal is recursive also, may be merged with rsimp
+    new_goal = makeSimpliestGoal(new_goal, hypotheses)
 
     new_goal = rsimp(new_goal, hypotheses, use_sympy)
 
@@ -128,6 +124,18 @@ def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic
         print(f"Simplified {goal} to {new_goal} using {hypotheses}.")
     return new_goal
 
+def makeSimpliestGoal(goal, hypotheses):
+    new_goal = goal
+    for hyp in hypotheses:
+        if isinstance(hyp,Boolean):
+            # If a hypothesis is a boolean, we can use it to simplify the goal further.
+            new_goal = new_goal.subs(hyp, True)
+            if isinstance(hyp, Not):
+                new_goal = new_goal.subs(hyp.args[0], False)
+    if new_goal != goal:
+        return makeSimpliestGoal(new_goal, hypotheses)
+    else:
+        return goal
 
 class SimpAll(Tactic):
     """

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -17,7 +17,6 @@ class TestAll(object):
         captured = capsys.readouterr()
         assert "Feasible with the following values:" in captured.out
 
-    @pytest.mark.skip(reason="https://github.com/teorth/estimates/issues/13")
     def test_case_split_solution(self, capsys):
         case_split_solution()
         self.proof_complete(capsys)


### PR DESCRIPTION
Without `repeat=True`, now the output of case_split_solution is constant as below:

```
Starting proof.  Current proof state:
P: bool
Q: bool
R: bool
S: bool
h1: P | Q
h2: R | S
|- (P & R) | (P & S) | (Q & R) | (Q & S)
Splitting h1: P | Q into cases P, Q.
2 goals remaining.
Simplified (P & R) | (P & S) | (Q & R) | (Q & S) to True using {Type((R,)), Type((P,)), Type((S,)), R | S, Type((Q,)), P}.
Goal solved!
1 goal remaining.
Simplified (P & R) | (P & S) | (Q & R) | (Q & S) to True using {Type((R,)), Type((P,)), Type((S,)), R | S, Type((Q,)), Q}.
Goal solved!
Proof complete!
```

Now the 23 test cases all pass, with little extra time cost when running.

As makeSimpliestGoal is recursively like rsimp, they may be able to be merged, so I left a TODO.

Besides `verbose_feasibility` seems to be not used any more, so cleaned up for now.