### PR TITLE
Always output conclusion message for linarith, in case counter exampl…

### DIFF
--- a/src/estimates/linarith.py
+++ b/src/estimates/linarith.py
@@ -121,8 +121,7 @@ class Linarith(Tactic):
                 print("Feasible with the following values:")
                 for var, value in dict.items():
                     print(f"{var} = {value}")
-            else:
-                print("Linear arithmetic was unable to prove goal.")
+            print("Linear arithmetic was unable to prove goal.")
             return [state.copy()]
         else:
             if self.verbose:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,6 @@ Under project directory, run:
 
 ## Notes
 
-It can take several minutes to run the tests, as `complex_littlewood_paley_solution` takes long.
+It can take some seconds to run the tests, as `complex_littlewood_paley_solution` takes longer.
 
 Currently solution output may differ because of the non-deterministic ordered data structure, tests only check if output contains characteristic substring like "Proof complete!" for now.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -15,7 +15,7 @@ class TestAll(object):
     def test_linarith_failure_example(self, capsys):
         linarith_failure_example()
         captured = capsys.readouterr()
-        assert "Feasible with the following values:" in captured.out
+        assert captured.out.endswith("Linear arithmetic was unable to prove goal.\n")
 
     def test_case_split_solution(self, capsys):
         case_split_solution()


### PR DESCRIPTION
Previously, when verbose==true, the conclusion message wasn't printed, which makes the output looks "unfinished".

BTW, the current message "Linear arithmetic was unable to prove goal" sounds like the goal might be provable by other means. With counter example already found, should the message be more decisive like "The goal is proved to be false"?