### PR TITLE
#21 validate counterexample before stating the goal is false

### DIFF
--- a/src/estimates/linarith.py
+++ b/src/estimates/linarith.py
@@ -14,7 +14,7 @@ from sympy import (
 from sympy.core.relational import Relational
 
 from estimates.basic import Type
-from estimates.linprog import Inequality, feasibility
+from estimates.linprog import Inequality, feasibility, is_valid_counterexample
 from estimates.proofstate import ProofState
 from estimates.tactic import Tactic
 
@@ -118,10 +118,14 @@ class Linarith(Tactic):
                 print("Checking feasibility of the following inequalities:")
                 for ineq in inequalities:
                     print(ineq)
-                print("Feasible with the following values:")
-                for var, value in dict.items():
-                    print(f"{var} = {value}")
-            print("Linear arithmetic was unable to prove goal.")
+
+                if is_valid_counterexample(dict):
+                    print("Feasible with the following values:")
+                    for var, value in dict.items():
+                        print(f"{var} = {value}")
+                    print("The counterexample proves the goal to be false.")
+                else:
+                    print("Linear arithmetic was unable to prove goal.")
             return [state.copy()]
         else:
             if self.verbose:

--- a/src/estimates/linprog.py
+++ b/src/estimates/linprog.py
@@ -2,7 +2,9 @@ from fractions import Fraction
 from numbers import Rational
 from typing import Literal
 
-from z3 import Real, Solver, Sum, sat
+from sympy import Pow
+
+from z3 import Real, Solver, Sum, sat, simplify
 
 # exact linear programming tools.
 
@@ -170,3 +172,10 @@ def feasibility(inequalities: list[Inequality]) -> tuple[bool, dict]:
         raise ValueError(
             f"Farkas lemma violation!  Problem is neither feasible nor infeasible. Inequalities: {inequalities}"
         )
+
+def is_valid_counterexample(dict):
+    for var, value in dict.items():
+        if isinstance(var, Pow) and var.base in dict:
+            if simplify(dict[var.base] ** var.exp != value):
+                return False
+    return True

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -12,10 +12,19 @@ class TestAll(object):
         linarith_solution()
         self.proof_complete(capsys)
 
-    def test_linarith_failure_example(self, capsys):
+    def test_linarith_false_goal_example(self, capsys):
         linarith_failure_example()
         captured = capsys.readouterr()
         assert captured.out.endswith("The counterexample proves the goal to be false.\n")
+
+    def test_linarith_failure_example(self, capsys):
+        p = ProofAssistant()
+        x = p.var("pos_real", "x")
+        p.assume(x < 2, "h1")
+        p.begin_proof(x ** 2 < 3)
+        p.use(Linarith(verbose=True))
+        captured = capsys.readouterr()
+        assert captured.out.endswith("Linear arithmetic was unable to prove goal.\n")
 
     def test_case_split_solution(self, capsys):
         case_split_solution()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -15,7 +15,7 @@ class TestAll(object):
     def test_linarith_failure_example(self, capsys):
         linarith_failure_example()
         captured = capsys.readouterr()
-        assert captured.out.endswith("Linear arithmetic was unable to prove goal.\n")
+        assert captured.out.endswith("The counterexample proves the goal to be false.\n")
 
     def test_case_split_solution(self, capsys):
         case_split_solution()


### PR DESCRIPTION
Based on [discussion here](https://github.com/teorth/estimates/pull/21#issuecomment-2963925600), if the counterexample is valid in case like `linarith_failure_example`, then states the goal is proved to be false; otherwise, use previous conclusion message.