### PR TITLE
Adding new required properties to tactics and lemmas

### DIFF
--- a/src/estimates/lemma.py
+++ b/src/estimates/lemma.py
@@ -42,6 +42,10 @@ class UseLemma(Tactic):
     def __str__(self) -> str:
         return f"{self.hyp} := {self.lemma}"
 
+    label = "Use lemma"
+    description = "Apply a lemma to the current proof state."
+    arguments = ["hypotheses"]
+
 
 class Amgm(Lemma):
     """

--- a/src/estimates/linarith.py
+++ b/src/estimates/linarith.py
@@ -154,3 +154,7 @@ class Linarith(Tactic):
 
     def __str__(self) -> str:
         return "linarith"
+    
+    label = "Linear arithmetic"
+    description = "A tactic to try to establish a goal via linear arithmetic.  Inspired by the linarith tactic in Lean."
+    arguments = ["verbose"]

--- a/src/estimates/log_linarith.py
+++ b/src/estimates/log_linarith.py
@@ -84,6 +84,10 @@ class ApplyTheta(Tactic):
         else:
             return f"{self.newhyp} := apply_theta {self.hyp}"
 
+    label = "Apply Theta"
+    description = "Apply the Theta function to a hypothesis to get its asymptotic form."
+    arguments = ["hypotheses"]
+
 
 def extract_monomials(expr: Basic) -> dict[Basic, Fraction]:
     """
@@ -418,3 +422,7 @@ class LogLinarith(Tactic):
             return "log_linarith!"
         else:
             return "log_linarith"
+    
+    label = "Log linear arithmetic"
+    description = "A tactic to establish a goal via logarithmic linear arithmetic for asymptotic inequalities."
+    arguments = ["verbose"]

--- a/src/estimates/propositional_tactics.py
+++ b/src/estimates/propositional_tactics.py
@@ -138,6 +138,10 @@ class SplitGoal(Tactic):
 
     def __str__(self) -> str:
         return "split_goal"
+    
+    label = "Split goal"
+    description = "Split the goal into its conjuncts.  If the goal is a conjunction, split the goal into one goal for each conjunct."
+    arguments = []
 
 
 class Contrapose(Tactic):
@@ -172,6 +176,10 @@ class Contrapose(Tactic):
             return "contrapose"
         else:
             return "contrapose " + self.h
+    
+    label = "Contrapositive"
+    description = 'If the hypothesis is a proposition, replace the goal with the negation of the hypothesis, and the hypothesis with the negation of the goal.  Otherwise, this becomes a proof by contradiction, adding the negation of the goal as a hypothesis, and "false" as the goal.'
+    arguments = ["hypotheses", "this"]
 
 
 class SplitHyp(Tactic):
@@ -215,6 +223,10 @@ class SplitHyp(Tactic):
                 return "split_hyp " + self.h
             else:
                 return "split_hyp " + self.h + " " + ", ".join(self.names)
+    
+    label = "Split hypothesis"
+    description = "Split a hypothesis into its conjuncts.  If the hypothesis is a conjunction, split the hypothesis into one hypothesis for each conjunct.  The new hypotheses will be named according to the names supplied in the constructor."
+    arguments = ["hypotheses", "this"]
 
 
 class Cases(Tactic):
@@ -246,6 +258,10 @@ class Cases(Tactic):
 
     def __str__(self) -> str:
         return "cases " + self.h
+    
+    label = "Cases"
+    description = "Split a hypothesis into its disjuncts.  If the hypothesis is a disjunction, split the hypothesis into one goal for each disjunct."
+    arguments = ["hypotheses"]
 
 
 class ByCases(Tactic):
@@ -278,6 +294,10 @@ class ByCases(Tactic):
         else:
             return "by_cases " + describe(self.name, self.statement)
 
+    label = "By cases"
+    description = "Split into two cases, depending on whether an assertion is true or false."
+    arguments = ["expressions"]
+
 
 class Option(Tactic):
     """
@@ -302,6 +322,10 @@ class Option(Tactic):
 
     def __str__(self) -> str:
         return "option " + str(self.n)
+
+    label = "Option"
+    description = "If the goal is a disjunction, replace it with one of its disjuncts."
+    arguments = []
 
 
 class Claim(Tactic):
@@ -345,3 +369,7 @@ class Claim(Tactic):
             return "claim " + str(self.expr)
         else:
             return "claim " + self.name + ": " + str(self.expr)
+    
+    label = "Claim"
+    description = "Similar to the `have` tactic in Lean.  Add a subgoal to prove, and then prove the original goal assuming the subgoal."
+    arguments = ["expressions"]

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -183,6 +183,10 @@ class SimpAll(Tactic):
 
     def __str__(self) -> str:
         return "simp_all"
+    
+    label = "Simplify"
+    description = "Simplifies each hypothesis using other hypotheses, then the goal using the hypothesis."
+    arguments = []
 
 
 class IsPositive(Tactic):
@@ -237,6 +241,10 @@ class IsPositive(Tactic):
     def __str__(self) -> str:
         return f"is_positive {self.name}"
 
+    label = "Make positive"
+    description = "Make a variable positive by searching for hypotheses that imply positivity."
+    arguments = ["variables", "this"]
+
 
 class IsNonnegative(Tactic):
     """
@@ -290,6 +298,10 @@ class IsNonnegative(Tactic):
     def __str__(self) -> str:
         return f"is_nonnegative {self.name}"
 
+    label = "Make nonnegative"
+    description = "Make a variable nonnegative by searching for hypotheses that imply nonnegativity."
+    arguments = ["variables", "this"]
+
 
 class IsNonzero(Tactic):
     """
@@ -342,6 +354,10 @@ class IsNonzero(Tactic):
 
     def __str__(self) -> str:
         return f"is_nonzero {self.name}"
+
+    label = "Make nonzero"
+    description = "Make a variable nonzero by searching for hypotheses that imply nonvanishing."
+    arguments = ["variables", "this"]
 
 
 class Calc(Tactic):
@@ -477,5 +493,9 @@ class Calc(Tactic):
 
     def __str__(self) -> str:
         return self.name
+
+    label = "Calc"
+    description = "Split an inequality goal into two or more subgoals, which chain together to recover the main goal."
+    arguments = ["expressions"]
 
                 

--- a/src/estimates/subst.py
+++ b/src/estimates/subst.py
@@ -38,6 +38,10 @@ class Let(Tactic):
     def __str__(self) -> str:
         return f"let {self.name} := {self.expr}"
 
+    label = "Let"
+    description = "Introduce a new variable, defined to equal a given expression."
+    arguments = ["variables", "expressions"]
+
 
 class Set(Tactic):
     """
@@ -75,6 +79,10 @@ class Set(Tactic):
 
     def __str__(self) -> str:
         return f"set {self.name} := {self.expr}"
+
+    label = "Set"
+    description = "Introduce a new variable, defined to equal a given expression, then substitute all instances of that expression with the variable."
+    arguments = ["variables", "expressions"]
 
 
 class Subst(Tactic):
@@ -150,6 +158,10 @@ class Subst(Tactic):
         else:
             return f"subst {name} at {self.target}"
 
+    label = "Substitute"
+    description = "Use an existing equality hypothesis to substitute all instances of one side with the other in the goal or a specified hypothesis."
+    arguments = ["hypotheses"]
+
 
 class SubstAll(Tactic):
     """
@@ -216,3 +228,7 @@ class SubstAll(Tactic):
     def __str__(self) -> str:
         name = "<-" + str(self.hyp) if self.reversed else str(self.hyp)
         return f"subst_all {name}"
+
+    label = "Substitute all"
+    description = "Use an existing equality hypothesis to substitute all instances of one side with the other in the goal and all other hypotheses."
+    arguments = ["hypotheses"]

--- a/src/estimates/tactic.py
+++ b/src/estimates/tactic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from estimates.proofstate import ProofState
@@ -19,3 +19,35 @@ class Tactic(ABC):
 
     @abstractmethod
     def __str__(self) -> str: ...
+
+
+    # Required properties for estimates-ui webapp integration
+    
+    @property
+    @abstractmethod
+    def label(self) -> str:
+        """
+        Short display name for the tactic button in the webapp UI.
+        Should be concise (1-3 words) and user-friendly.
+        """
+        ...
+    
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """
+        User-facing explanation of what this tactic does.
+        Displayed in full as a description in the webapp interface.
+        Should be a few sentences long.
+        """
+        ...
+    
+    @property
+    @abstractmethod
+    def arguments(self) -> list[Literal["variables", "hypotheses", "verbose", "this", "expressions"]]:
+        """
+        Input types this tactic accepts from the webapp.
+        Determines which UI input fields are shown to the user for this tactic.
+        Valid options: variables, hypotheses, verbose, this, expressions
+        """
+        ...

--- a/src/estimates/test.py
+++ b/src/estimates/test.py
@@ -45,3 +45,7 @@ class Trivial(Tactic):
 
     def __str__(self) -> str:
         return "trivial"
+    
+    label = "Trivial"
+    description = "A tactic to prove a goal that is trivially true, can be applied to any goal."
+    arguments = []


### PR DESCRIPTION
Follows up on [this note](https://github.com/teorth/estimates/issues/12#issuecomment-3000941888) to:
1. Add new abstract properties required for tactics, ensuring that instantiating a tactic fails if those values are not available on the object
2. Turn `Lemma` into an abstract class with the same required properties
3. Set initial values for these properties on all existing tactics and lemmas

Two notes:
1. I chose to list the required properties twice (once on Lemma and once on Tactic) as I believe it reduces complexity. Should it be repeated a third time I would vote to create a shared parent.
2. The repo's implemetation of`UseLemma` as a distinct tactic differs from how the UI currently handles Lemmas (granting each one first-class status, similar to tactics). I'll follow up in the main thread to see if that approach is ergonomic or not.

<img width="435" alt="image" src="https://github.com/user-attachments/assets/5ceaadb7-0670-40d3-87aa-1ddb228195a7" />