### PR TITLE
[LOGIC]: Fix counterexample validation

### DIFF
--- a/src/estimates/linprog.py
+++ b/src/estimates/linprog.py
@@ -176,6 +176,6 @@ def feasibility(inequalities: list[Inequality]) -> tuple[bool, dict]:
 def is_valid_counterexample(dict):
     for var, value in dict.items():
         if isinstance(var, Pow) and var.base in dict:
-            if simplify(dict[var.base] ** var.exp != value):
+            if simplify(dict[var.base] ** var.exp) != value:
                 return False
     return True


### PR DESCRIPTION
I think that there was a small issue concerning the brackets because simplifying a bool value is probably not the intended behaviour.

(I've not tested the changes, but I'm pretty confident that this fix is required.)

Contributed by Benedikt Johannes