### PR TITLE
Use SimpAll(repeat=True) in case_split_solution

### DIFF
--- a/src/estimates/main.py
+++ b/src/estimates/main.py
@@ -61,7 +61,7 @@ def case_split_exercise() -> ProofAssistant:
 def case_split_solution() -> None:
     p = case_split_exercise()
     p.use(Cases("h1"))
-    p.all_goals_use(SimpAll())
+    p.all_goals_use(SimpAll(repeat=True))
 
 def split_exercise() -> ProofAssistant:
     p = ProofAssistant()


### PR DESCRIPTION
Fixes #13

## Bug
`case_split_solution()` intermittently crashes with `ValueError: Cannot apply tactics in assumption mode` when `SimpAll()` solves one branch early under an unlucky hypothesis ordering.

## Root cause
`SimpAll()` without `repeat=True` can finish simplification in a state that leaves later goals in assumption mode; ordering of Python `set`/`dict` iteration makes this non-deterministic.

## Why this fix is correct
`SimpAll(repeat=True)` iterates until the goal stabilizes, which the maintainer noted fixes this specific failure mode. Wiring it into the demo solution matches the documented workaround.

## Test plan
- [ ] Run `case_split_solution()` repeatedly; no assumption-mode errors

Made with [Cursor](https://cursor.com)