### PR TITLE
fix: use Linarith in amgm example on lemmas page

### DIFF
--- a/docs/lemmas.md
+++ b/docs/lemmas.md
@@ -24,7 +24,7 @@ y: nonneg_real
 >>> p.use_lemma(Amgm(x**2,y**2))
 Applying lemma am_gm(x**2, y**2) to conclude this: x**1.0*y**1.0 <= x**2/2 + y**2/2.
 1 goal remaining.
->>> p.use(SimpAll())
-Goal solved!
+>>> p.use(Linarith())
+Goal solved by linear arithmetic!
 Proof complete!
 ```


### PR DESCRIPTION
## Summary
Issue #19: the amgm exercise does not complete with `SimpAll()`; it stops at `sorry`.

## Root cause
README was switched to `Linarith()` after #4, but `docs/lemmas.md` still told readers to run `SimpAll()` and claimed the proof finished.

## Fix
Match the working recipe already used in README and the UI tutorial.

Made with [Cursor](https://cursor.com)