### PR TITLE
fix: remove duplicate Amgm step in README amgm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,6 @@ y: nonneg_real
 |- 2*x*y <= x**2 + y**2
 >>> x,y = p.get_vars("x","y")
 >>> p.use_lemma(Amgm(x**2,y**2))
->>> p.use_lemma(Amgm(x**2,y**2))
 Applying lemma am_gm(x**2, y**2) to conclude this: x*y <= x**2/2 + y**2/2.
 1 goal remaining.
 >>> p.use(Linarith())


### PR DESCRIPTION
## Summary
The README amgm walkthrough listed `use_lemma(Amgm(...))` twice, so the transcript no longer matches a valid proof after #19 switched the finish to `Linarith()`.

## Root cause
When the example was updated from `SimpAll()` to `Linarith()`, an extra duplicate input line was left in the session log.

## Fix
Drop the spurious second `use_lemma` line so the documented steps match `amgm_solution()`.


Made with [Cursor](https://cursor.com)