### PR TITLE
fix: correct AM-GM denominator in lemmas.md

### DIFF
--- a/docs/lemmas.md
+++ b/docs/lemmas.md
@@ -10,7 +10,7 @@ The reflexive axiom `expr = expr`.
 
 ## Amgm(x_1, ..., x_n)
 
-The arithmetic mean-geometric mean inequality $(x_1 \dots X_n)^{1/n} \leq \frac{x_1+\dots+x_n}{2}$.  Needs the $x_i$ to be non-negative in order to be applied.
+The arithmetic mean-geometric mean inequality $(x_1 \dots x_n)^{1/n} \leq \frac{x_1+\dots+x_n}{n}$.  Needs the $x_i$ to be non-negative in order to be applied.
 
 Example:
 ```


### PR DESCRIPTION
## Summary
- Fix the `Amgm` lemma description on the lemmas page to divide by `n` instead of `2`, and correct `X_n` to `x_n`.
- Aligns the documented statement with `Amgm.apply()` and the README.

## Test plan
- [x] Verified the one-line change matches `lemma.py` (`sum / len(self.vars)`) and README wording.


Made with [Cursor](https://cursor.com)