### PR TITLE
fix: correct AM-GM geometric mean in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ For a full list of navigation commands that one can perform in either **Assumpti
 
 ## Lemmas
 
-In addition to general proof tactics, I plan to build a [library of lemmas](docs/lemmas.md) that can be used for more specialized applications.  Here is one example, using an arithmetic mean geometric mean lemma $(x_1+\dots+x_n)^{1/n} \leq \frac{x_1+\dots+x_n}{n}$ to prove a slight variant of that lemma:
+In addition to general proof tactics, I plan to build a [library of lemmas](docs/lemmas.md) that can be used for more specialized applications.  Here is one example, using an arithmetic mean geometric mean lemma $(x_1 \dots x_n)^{1/n} \leq \frac{x_1+\dots+x_n}{n}$ to prove a slight variant of that lemma:
 ```
 >>> from estimates.main import *
 >>> p = amgm_exercise()


### PR DESCRIPTION
## Summary
- Geometric mean was written as a sum; use the product form to match `docs/lemmas.md`.

## Test plan
- [x] Diff against lemmas.md AM-GM statement