### PR TITLE
fix: stop SimpAll(repeat=True) from looping forever

### DIFF
--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -150,7 +150,10 @@ class SimpAll(Tactic):
         newstate = state.copy()
 
         while True:
-            for name, hyp in state.hypotheses.items():
+            prev = newstate.copy()
+            # Iterate a snapshot of the *current* hypotheses; the old loop walked the
+            # original ``state`` and compared to it, so ``repeat=True`` never stabilized.
+            for name, hyp in list(newstate.hypotheses.items()):
                 other_hypotheses = set()
                 for other_name, other_hyp in newstate.hypotheses.items():
                     if other_name != name:  # Cannot use a hypothesis to simplify itself!
@@ -172,13 +175,13 @@ class SimpAll(Tactic):
             if goal == true:
                 print("Goal solved!")
                 return []
-            
+
             if not self.repeat:
                 break
 
-            if newstate.eq(state):
-                break  # if repeat is True, we keep simplifying until the goal stabilizes
-    
+            if newstate.eq(prev):
+                break  # if repeat is True, we keep simplifying until the state stabilizes
+
         return [newstate]
 
     def __str__(self) -> str:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,17 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_simpall_repeat_terminates(self, capsys):
+        """SimpAll(repeat=True) must stabilize instead of looping forever."""
+        from sympy import Or
+        p = ProofAssistant()
+        p.var("bool", "P")
+        p.var("bool", "Q")
+        p.assume(p.get_var("P"), "hP")
+        p.assume(Or(p.get_var("P"), p.get_var("Q")), "hOr")
+        p.begin_proof(p.get_var("Q"))
+        p.use(SimpAll(repeat=True))
+        # Must return without hanging; goal may remain if not fully solved.
+        assert True
+


### PR DESCRIPTION
## Summary
- `SimpAll(repeat=True)` compared each pass to the original state, so it never stabilized after a change.
- Iterate/compare the current state each round.

## Test plan
- [x] Regression test that previously hung now finishes