### PR TITLE
fix: LogLinarith GreaterThan direction

### DIFF
--- a/src/estimates/log_linarith.py
+++ b/src/estimates/log_linarith.py
@@ -296,10 +296,12 @@ class LogLinarith(Tactic):
                             )
                         ]
                     elif isinstance(hypothesis, GreaterThan | StrictGreaterThan):
+                        # Keep argument order (same as LessThan -> "<="); swapping
+                        # both sides and using ">=" inverted the relation.
                         newhypotheses = [
                             Rel(
-                                Theta(hypothesis.args[1]),
                                 Theta(hypothesis.args[0]),
+                                Theta(hypothesis.args[1]),
                                 ">=",
                             )
                         ]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -121,6 +121,4 @@ class TestAll(object):
         p.use(LogLinarith())
         out = capsys.readouterr().out
         assert "Proof complete!" not in out
-        assert "unable to prove" in out or "Goal solved" not in out or "remaining" in out.lower() or True
-        # After fix, should not claim complete from reversed inequality.
-        assert "Proof complete!" not in out
+        assert "unable to prove goal" in out

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,17 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_loglinarith_greaterthan_not_reversed(self, capsys):
+        """x > y must not prove Theta(y) >= Theta(x)."""
+        from estimates.order_of_magnitude import Theta
+        p = ProofAssistant()
+        x, y = p.var("pos_real", "x"), p.var("pos_real", "y")
+        p.assume(x > y, "h")
+        p.begin_proof(Theta(y) >= Theta(x))
+        p.use(LogLinarith())
+        out = capsys.readouterr().out
+        assert "Proof complete!" not in out
+        assert "unable to prove" in out or "Goal solved" not in out or "remaining" in out.lower() or True
+        # After fix, should not claim complete from reversed inequality.
+        assert "Proof complete!" not in out


### PR DESCRIPTION
## Summary
- `x > y` was encoded as `Theta(y) >= Theta(x)`, reversing the inequality.
- Mirror `LessThan`: keep argument order and use `>=`.

## Test plan
- [x] `test_loglinarith_greaterthan_not_reversed`