### PR TITLE
fix: LogLinarith Ne disjunct nesting

### DIFF
--- a/src/estimates/log_linarith.py
+++ b/src/estimates/log_linarith.py
@@ -259,19 +259,18 @@ class LogLinarith(Tactic):
                     hypothesis.args[1], OrderOfMagnitude
                 ):
                     if isinstance(hypothesis, Ne):
+                        # Disjuncts for product(*inequality_lists); both must be Rel, not a nested list.
                         newhypotheses = [
                             Rel(
                                 Theta(hypothesis.args[0]),
                                 Theta(hypothesis.args[1]),
                                 "<",
                             ),
-                            [
-                                Rel(
-                                    Theta(hypothesis.args[0]),
-                                    Theta(hypothesis.args[1]),
-                                    ">",
-                                )
-                            ],
+                            Rel(
+                                Theta(hypothesis.args[0]),
+                                Theta(hypothesis.args[1]),
+                                ">",
+                            ),
                         ]
                     else:
                         newhypotheses = [hypothesis]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,14 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_loglinarith_ne_orders(self, capsys):
+        """Ne between orders must not crash LogLinarith."""
+        from sympy import Ne
+        p = ProofAssistant()
+        X, Y = p.var("order", "X"), p.var("order", "Y")
+        p.assume(Ne(X, Y), "h")
+        p.begin_proof(X <= Y)
+        p.use(LogLinarith())
+        # Should run without AttributeError; may or may not solve.
+        assert True


### PR DESCRIPTION
## Summary
- `Ne` wrapped the second disjunct in an extra list, so `max_objects` hit a list and crashed.
- Flatten to two `Rel` siblings for `product(*inequality_lists)`.

## Test plan
- [x] `test_loglinarith_ne_orders`