### PR TITLE
fix: SubstAll no-effect detection

### DIFF
--- a/src/estimates/subst.py
+++ b/src/estimates/subst.py
@@ -218,7 +218,7 @@ class SubstAll(Tactic):
                 )
         newstate.set_goal(newtarget)
 
-        if newstate == state:
+        if newstate.eq(state):
             print("Substitution had no effect.")
         if newtarget == true:
             print("Goal proved!")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,13 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_substall_no_effect_message(self, capsys):
+        """SubstAll should report when substitution changes nothing."""
+        p = ProofAssistant()
+        x, y, z = p.var("real", "x"), p.var("real", "y"), p.var("real", "z")
+        p.assume(Eq(x, y), "h")
+        p.begin_proof(z > 0)
+        p.use(SubstAll("h"))
+        out = capsys.readouterr().out
+        assert "Substitution had no effect." in out


### PR DESCRIPTION
## Summary
- `SubstAll` compared proof states with `==` (identity), so “no effect” never printed after `copy()`.
- Use `ProofState.eq`, same as `SimpAll`.

## Test plan
- [x] `test_substall_no_effect_message`