### PR TITLE
fix: allow Theta on Abs when positivity unknown

### DIFF
--- a/src/estimates/order_of_magnitude.py
+++ b/src/estimates/order_of_magnitude.py
@@ -116,7 +116,13 @@ class Theta(OrderOfMagnitude, Expr):
         if isinstance(expr, OrderOfMagnitude):
             return expr
 
-        if not expr.is_positive:
+        # Abs(x) is nonnegative but sympy often leaves .is_positive as None (zero possible).
+        # Still a valid order of magnitude when not identically zero.
+        if expr.is_positive:
+            pass
+        elif expr.is_nonnegative is True and expr.is_zero is not True:
+            pass
+        else:
             print(f"Warning: a non-positive argument {expr!s} was passed to Theta.")
             return Undefined()
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,12 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_theta_abs_nonnegative(self):
+        """Theta(Abs(n)) must not become Undefined when positivity is unknown."""
+        from sympy import Abs, Symbol
+        from estimates.order_of_magnitude import Theta, Undefined
+        n = Symbol("n", integer=True)
+        t = Theta(Abs(n))
+        assert not isinstance(t, Undefined)
+        assert str(t).startswith("Theta")


### PR DESCRIPTION
## Summary
- `Abs(n).is_positive` is often `None`, so `Theta(Abs(n))` wrongly returned `Undefined`.
- Accept nonnegative expressions that are not identically zero.

## Test plan
- [x] `test_theta_abs_nonnegative`