### PR TITLE
fix: interpolate proofassistant navigation messages

### DIFF
--- a/src/estimates/proofassistant.py
+++ b/src/estimates/proofassistant.py
@@ -297,7 +297,7 @@ class ProofAssistant:
                 )
             else:
                 self.current_node = node
-                print(f'Moved to a proof state currently handled by "{node.tactic}").')
+                print(f'Moved to a proof state currently handled by "{node.tactic}".')
         else:
             raise ValueError("Cannot set current node in assumption mode.")
 
@@ -371,7 +371,7 @@ class ProofAssistant:
                 print("There are no more steps in this branch of the proof.")
             elif case > len(self.current_node.children):
                 print(
-                    "There are only {len(self.current_node.children)} cases after this step of the proof."
+                    f"There are only {len(self.current_node.children)} cases after this step of the proof."
                 )
             else:
                 self.set_current_node(self.current_node.children[case - 1])
@@ -384,7 +384,7 @@ class ProofAssistant:
                 elif case == 3:
                     print("Moved forward to the third case of this step in the proof.")
                 else:
-                    print("Moved forward to case {case} of this step in the proof.")
+                    print(f"Moved forward to case {case} of this step in the proof.")
         else:
             raise ValueError("Cannot move forward in assumption mode.")
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,21 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_go_forward_messages(self, capsys):
+        """go_forward should interpolate case counts in messages."""
+        from sympy import Or, Eq
+        p = ProofAssistant()
+        x = p.var("real", "x")
+        p.assume(Or(Eq(x, 0), Eq(x, 1), Eq(x, 2), Eq(x, 3)), "h")
+        p.begin_proof(x >= 0)
+        p.use(Cases("h"))
+        capsys.readouterr()
+        p.go_forward(99)
+        out = capsys.readouterr().out
+        assert "{len(" not in out
+        assert "4 cases" in out
+        p.go_forward(4)
+        out = capsys.readouterr().out
+        assert "{case}" not in out
+        assert "case 4" in out

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -119,6 +119,7 @@ class TestAll(object):
         p.assume(Or(Eq(x, 0), Eq(x, 1), Eq(x, 2), Eq(x, 3)), "h")
         p.begin_proof(x >= 0)
         p.use(Cases("h"))
+        p.go_back()
         capsys.readouterr()
         p.go_forward(99)
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- `go_forward` printed literal `{case}` / `{len(...)}` without f-strings.
- Dropped a stray `)` in the `set_current_node` message.

## Test plan
- [x] `test_go_forward_messages`