### PR TITLE
fix: typeof(var) in type-tactic inconsistency errors

### DIFF
--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -220,7 +220,7 @@ class IsPositive(Tactic):
             newvar = new_var("pos_real", name)
         else:
             raise ValueError(
-                f"INCONSISTENCY: {name}:{typeof} was somehow proven positive, which is impossible."
+                f"INCONSISTENCY: {name}:{typeof(var)} was somehow proven positive, which is impossible."
             )
 
         print(f"{name} is now of type {typeof(newvar)}.")
@@ -277,7 +277,7 @@ class IsNonnegative(Tactic):
             newvar = new_var("nonneg_real", name)
         else:
             raise ValueError(
-                f"INCONSISTENCY: {name}:{typeof} was somehow proven nonnegative, which is impossible."
+                f"INCONSISTENCY: {name}:{typeof(var)} was somehow proven nonnegative, which is impossible."
             )
 
         print(f"{name} is now of type {typeof(newvar)}.")
@@ -334,7 +334,7 @@ class IsNonzero(Tactic):
             newvar = new_var("nonzero_real", name)
         else:
             raise ValueError(
-                f"INCONSISTENCY: {name}:{typeof} was somehow proven positive, which is impossible."
+                f"INCONSISTENCY: {name}:{typeof(var)} was somehow proven nonzero, which is impossible."
             )
 
         print(f"{name} is now of type {typeof(newvar)}.")

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,14 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_type_tactic_inconsistency_messages(self):
+        """Inconsistency errors should call typeof(var), and IsNonzero should say nonzero."""
+        import inspect
+        from estimates.simp import IsNonzero, IsPositive, IsNonnegative
+        src = inspect.getsource(IsNonzero.activate)
+        assert "typeof(var)" in src
+        assert "proven nonzero" in src
+        assert "proven positive" not in src
+        assert "typeof(var)" in inspect.getsource(IsPositive.activate)
+        assert "typeof(var)" in inspect.getsource(IsNonnegative.activate)


### PR DESCRIPTION
## Summary
- Inconsistency messages used `{typeof}` (the function object) instead of `{typeof(var)}`.
- `IsNonzero` said "proven positive"; say "nonzero".

## Test plan
- [x] `test_type_tactic_inconsistency_messages`