### PR TITLE
fix: split Eq when Max/Min is on the left

### DIFF
--- a/src/estimates/propositional_tactics.py
+++ b/src/estimates/propositional_tactics.py
@@ -35,20 +35,26 @@ def get_conjuncts(expr: Basic) -> Sequence[Basic] | None:
     if isinstance(expr, And):
         return expr.args
     elif isinstance(expr, Eq):
-        if isinstance(expr.args[1], Max | OrderMax):
+        lhs, rhs = expr.args
+        # Max(y,z) = x is the same as x = Max(y,z); normalize Max/Min to the RHS.
+        if isinstance(lhs, Max | OrderMax | Min | OrderMin) and not isinstance(
+            rhs, Max | OrderMax | Min | OrderMin
+        ):
+            return get_conjuncts(Eq(rhs, lhs, evaluate=False))
+        if isinstance(rhs, Max | OrderMax):
             # x = Max(y,z) can be split into x >= y, x >= z, and (x == y) | (x == z)
             disjuncts = []
-            for arg in expr.args[1].args:
-                conjuncts.append(expr.args[0] >= arg)
-                disjuncts.append(Eq(expr.args[0], arg))
+            for arg in rhs.args:
+                conjuncts.append(lhs >= arg)
+                disjuncts.append(Eq(lhs, arg))
             conjuncts.append(Or(*disjuncts))
             return conjuncts
-        elif isinstance(expr.args[1], Min | OrderMin):
+        elif isinstance(rhs, Min | OrderMin):
             # x = Min(y,z) can be split into x <= y, x <= z, and (x == y) | (x == z)
             disjuncts = []
-            for arg in expr.args[1].args:
-                conjuncts.append(expr.args[0] <= arg)
-                disjuncts.append(Eq(expr.args[0], arg))
+            for arg in rhs.args:
+                conjuncts.append(lhs <= arg)
+                disjuncts.append(Eq(lhs, arg))
             conjuncts.append(Or(*disjuncts))
             return conjuncts
     elif isinstance(expr, LessThan | StrictLessThan):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,14 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_eq_max_lhs_conjuncts(self):
+        """Max(y, z) = x should split like x = Max(y, z)."""
+        from sympy import Max, Min, symbols, Eq
+        from estimates.propositional_tactics import get_conjuncts
+        x, y, z = symbols("x y z", real=True)
+        rhs = get_conjuncts(Eq(x, Max(y, z)))
+        lhs = get_conjuncts(Eq(Max(y, z), x))
+        assert lhs is not None and rhs is not None
+        assert len(lhs) == len(rhs)
+        assert get_conjuncts(Eq(Min(y, z), x)) is not None


### PR DESCRIPTION
## Summary
- `get_conjuncts` only unpacked `x = Max(...)` / `x = Min(...)`.
- Normalize `Max(...) = x` (and Min) to the RHS form before splitting.

## Test plan
- [x] `test_eq_max_lhs_conjuncts`