### PR TITLE
fix: avoid shared mutable default hypothesis sets

### DIFF
--- a/src/estimates/bounded.py
+++ b/src/estimates/bounded.py
@@ -44,10 +44,12 @@ class Bounded(Boolean):
     def __repr__(self) -> str:
         return self.name
 
-def is_fixed(expr: Expr, hypotheses:set[Basic] = set()) -> bool:
+def is_fixed(expr: Expr, hypotheses: set[Basic] | None = None) -> bool:
     """
     Check if an expression is fixed, given a set of hypotheses.  Only the hypotheses that are IsFixed objects will be used to determine if the expression is fixed.
     """
+    if hypotheses is None:
+        hypotheses = set()
 
     if expr.is_number:
         return True   # numerical quantities are always fixed
@@ -65,10 +67,12 @@ def is_fixed(expr: Expr, hypotheses:set[Basic] = set()) -> bool:
 
     return False
 
-def is_bounded(expr: Expr, hypotheses:set[Basic] = set()) -> bool:
+def is_bounded(expr: Expr, hypotheses: set[Basic] | None = None) -> bool:
     """
     Check if an expression is bounded, given a set of hypotheses.  Only the hypotheses that are IsFixed or IsBounded objects will be used to determine if the expression is bounded.
     """
+    if hypotheses is None:
+        hypotheses = set()
 
     if expr.is_number:
         return True   # numerical quantities are always bounded

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -20,9 +20,11 @@ from estimates.bounded import is_fixed, is_bounded
 #  The simplifier
 
 
-def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Basic:
+def rsimp(goal: Basic, hypotheses: set[Basic] | None = None, use_sympy = False) -> Basic:
     """
     Recursively simplifies the goal using a set of hypotheses.  If `use_sympy` is True, it uses sympy's simplifier."""
+    if hypotheses is None:
+        hypotheses = set()
 
     new_args = [rsimp(arg, hypotheses) for arg in goal.args]
 
@@ -90,10 +92,12 @@ def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Bas
         return goal.func(*new_args).doit()
 
 
-def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic:
+def simp(goal: Basic, hypotheses: set[Basic] | None = None, use_sympy = False) -> Basic:
     """
     Simplifies the goal using the hypothesis.  If `use_sympy` is True, it uses sympy's simplifier.
     """
+    if hypotheses is None:
+        hypotheses = set()
 
     if isinstance(goal, Type):
         # do not attempt to simplify variable declarations.  This is done by a separate tactic.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,12 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_no_mutable_hypothesis_defaults(self):
+        """is_fixed/is_bounded/simp/rsimp must not share a mutable default set."""
+        from estimates.bounded import is_fixed, is_bounded
+        from estimates.simp import simp, rsimp
+        assert is_fixed.__defaults__ == (None,)
+        assert is_bounded.__defaults__ == (None,)
+        assert simp.__defaults__[0] is None
+        assert rsimp.__defaults__[0] is None


### PR DESCRIPTION
## Summary
- `is_fixed`/`is_bounded`/`simp`/`rsimp` used `hypotheses=set()` defaults.
- Switch to `None` and allocate a fresh set per call.

## Test plan
- [x] `test_no_mutable_hypothesis_defaults`