### PR TITLE
fix: annotate min_objects as returning a set

### DIFF
--- a/src/estimates/log_linarith.py
+++ b/src/estimates/log_linarith.py
@@ -178,8 +178,8 @@ def max_objects(expr: Basic) -> set[Basic]:
         return set()
 
 
-def min_objects(expr: Basic) -> list[Basic]:
-    """Returns a list of the objects in the expression that are of type OrderMin."""
+def min_objects(expr: Basic) -> set[Basic]:
+    """Returns a set of the objects in the expression that are of type OrderMin."""
     if isinstance(expr, OrderMin):
         objects = {expr}
         for arg in expr.args:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,12 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_min_objects_returns_set(self):
+        """min_objects is annotated/implemented as a set, not a list."""
+        from estimates.log_linarith import min_objects
+        from estimates.order_of_magnitude import OrderMin, Theta
+        from sympy import symbols
+        x, y = symbols("x y", positive=True)
+        objs = min_objects(OrderMin(Theta(x), Theta(y)))
+        assert isinstance(objs, set)


### PR DESCRIPTION
## Summary
- `min_objects` always built and returned a `set`, but was annotated as `list`.
- Fix the annotation and docstring.

## Test plan
- [x] `test_min_objects_returns_set`