### PR TITLE
fix: stop asymp from becoming True on failed Theta

### DIFF
--- a/src/estimates/order_of_magnitude.py
+++ b/src/estimates/order_of_magnitude.py
@@ -409,7 +409,7 @@ def gg(expr1: Expr, expr2: Expr) -> Relational:
     """
     The formal assertion that expr1 is asymptotically much greater than expr2.
     """
-    return Theta(expr1) > Theta(abs(expr2))
+    return Theta(abs(expr1)) > Theta(abs(expr2))
 
 
 Expr.gg = gg
@@ -419,7 +419,7 @@ def gtrsim(expr1: Expr, expr2: Expr) -> Relational:
     """
     The formal assertion that expr1 is greater than or comparable to expr2.
     """
-    return Theta(expr1) >= Theta(abs(expr2))
+    return Theta(abs(expr1)) >= Theta(abs(expr2))
 
 
 Expr.gtrsim = gtrsim
@@ -429,7 +429,9 @@ def asymp(expr1: Expr, expr2: Expr) -> Relational:
     """
     The formal assertion that expr1 is asymptotically equivalent to expr2.
     """
-    return Eq(Theta(expr1), Theta(expr2))
+    # Wrap abs like ll/lesssim. evaluate=False so Undefined≠Undefined does not
+    # collapse to True when Theta rejects a non-positive argument.
+    return Eq(Theta(abs(expr1)), Theta(abs(expr2)), evaluate=False)
 
 
 Expr.asymp = asymp

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,12 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_asymp_not_tautology(self):
+        """asymp on plain reals must not collapse to True via Undefined==Undefined."""
+        from sympy import Symbol
+        from estimates.order_of_magnitude import asymp
+        a, b = Symbol("a", real=True), Symbol("b", real=True)
+        r = asymp(a, b)
+        assert r is not True
+        assert r != True


### PR DESCRIPTION
## Summary
- `Eq(Theta(a), Theta(b))` collapsed to `True` when both Thetas were `Undefined`.
- Wrap `abs` like `ll`/`lesssim`, and use `evaluate=False`. Also wrap the left side of `gg`/`gtrsim`.

## Test plan
- [x] `test_asymp_not_tautology`