### PR TITLE
fix: drop stray paren in ApplyTheta string form

### DIFF
--- a/src/estimates/log_linarith.py
+++ b/src/estimates/log_linarith.py
@@ -80,7 +80,7 @@ class ApplyTheta(Tactic):
 
     def __str__(self) -> str:
         if self.newhyp is None:
-            return f"apply_theta {self.hyp})"
+            return f"apply_theta {self.hyp}"
         else:
             return f"{self.newhyp} := apply_theta {self.hyp}"
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -110,3 +110,7 @@ class TestAll(object):
     def test_sympy_simplify_solution(self, capsys):
         sympy_simplify_solution()
         self.proof_complete(capsys)
+
+    def test_apply_theta_str(self):
+        from estimates.log_linarith import ApplyTheta
+        assert str(ApplyTheta("h")) == "apply_theta h"


### PR DESCRIPTION
## Summary
- `str(ApplyTheta("h"))` printed `apply_theta h)`.

## Test plan
- [x] `test_apply_theta_str`