### PR TITLE
fix: ProofTree tactic guard, exact bracket/sqrt, linprog docs

### DIFF
--- a/docs/linprog.md
+++ b/docs/linprog.md
@@ -1,42 +1,26 @@
-# Exact linear programming 
+# Exact linear programming
 
-The file [linprog.py](../src/linprog.py) is a exact linear programming wrapper that utilizes the Z3 linear programming package.  It introduces a class `Inequality` that describes formal linear inequalities between variables, constructed by `Inequality(coeffs, sense, rhs)`, where `coeffs` is a dictionary of pairs `variable : coefficient` with the coefficient `coefficient` a rational number (using the `Fraction` python package) and `variable` an arbitrary object, `sense` is one of `"lt"`, `"leq"`, `"eq"`, `"gt"`, `"geq"`, and `rhs` is another rational number.  Given a set `inequalities` of `Inequality` objects, the `feasibility(inequalities)` routine will determine whether this set of inequalities is feasible, providing a proof certificate in both the feasible and infeasible cases.  Specifically:
+The file [linprog.py](../src/estimates/linprog.py) is an exact linear programming wrapper that utilizes the Z3 linear programming package.  It introduces a class `Inequality` that describes formal linear inequalities between variables, constructed by `Inequality(coeffs, sense, rhs)`, where `coeffs` is a dictionary of pairs `variable : coefficient` with the coefficient `coefficient` a rational number (using the `Fraction` python package) and `variable` an arbitrary object, `sense` is one of `"lt"`, `"leq"`, `"eq"`, `"gt"`, `"geq"`, and `rhs` is another rational number.  Given a set `inequalities` of `Inequality` objects, the `feasibility(inequalities)` routine will determine whether this set of inequalities is feasible, providing a proof certificate in both the feasible and infeasible cases.  Specifically:
 
-- If the inequalities are feasible, it will provide as part of its output an assignment of a rational number to each variable that satisfies all the inequalities.
-- If the inequalities are infeasible, it will provide as part of its output specific rational numbers that one can multiply each inequality with, such that they sum to an inconsistent inequality such as $0 < 0$ or $1 \leq 0$.
-
-The `verbose_feasibility(inequalities)` method is similar, but outputs these certificates as console text rather than as a data type.
+- If the inequalities are feasible, it returns `(True, assignment)`, where `assignment` maps each variable to a rational value satisfying all the inequalities.
+- If the inequalities are infeasible, it returns `(False, multipliers)`, where `multipliers` maps each inequality to a rational coefficient such that a non-negative linear combination yields an inconsistent relation (e.g. `0 < 0` or `1 ≤ 0`).
 
 Unlike floating-point linear arithmetic packages, the tool here is exact and can handle both strict and non-strict inequalities with no possibility of roundoff error.  (But in order to do this, the coefficients are required to be rational numbers.  In principle one can use symbolic math packages to handle other types of numbers with computable ordering, but that is a future project.)
 
 ## Examples:
 
 ```
->>> inequalities = set()
->>> inequalities.add(Inequality({'x': 1}, 'leq', 3))         # x <= 3
->>> inequalities.add(Inequality({'y': 1}, 'leq', 2))         # y <= 2
->>> inequalities.add(Inequality({'x': 1, 'y': 1}, 'geq', 5)) # x+y >= 5
->>> verbose_feasibility(inequalities)    
+>>> from fractions import Fraction
+>>> from estimates.linprog import Inequality, feasibility
+>>> inequalities = []
+>>> inequalities.append(Inequality({'x': Fraction(1)}, 'leq', Fraction(3)))         # x <= 3
+>>> inequalities.append(Inequality({'y': Fraction(1)}, 'leq', Fraction(2)))         # y <= 2
+>>> inequalities.append(Inequality({'x': Fraction(1), 'y': Fraction(1)}, 'geq', Fraction(5))) # x+y >= 5
+>>> feasibility(inequalities)
+(True, {'y': 2, 'x': 3})
 
-Checking feasibility of the following inequalities:
-1*x <= 3
-1*y <= 2
-1*x + 1*y >= 5
-Feasible with the following values:
-y = 2
-x = 3
-
->>> inequalities.add(Inequality({'x': 1, 'y': 1}, 'gt', 5))  # x+y > 5
->>> verbose_feasibility(inequalities)    
-
-Checking feasibility of the following inequalities:
-1*x <= 3
-1*y <= 2
-1*x + 1*y > 5
-1*x + 1*y >= 5
-Infeasible by summing the following:
-1*x <= 3 multiplied by -1
-1*y <= 2 multiplied by -1
-1*x + 1*y > 5 multiplied by 1
+>>> inequalities.append(Inequality({'x': Fraction(1), 'y': Fraction(1)}, 'gt', Fraction(5)))  # x+y > 5
+>>> feasible, certificate = feasibility(inequalities)
+>>> feasible
+False
 ```
-

--- a/src/estimates/littlewood_paley.py
+++ b/src/estimates/littlewood_paley.py
@@ -1,5 +1,6 @@
 from fractions import Fraction
 
+from sympy import S
 from sympy.core.expr import Expr
 from sympy.logic.boolalg import BooleanFunction
 
@@ -9,14 +10,15 @@ from estimates.order_of_magnitude import Theta, asymp
 
 
 def sqrt(x: Expr) -> Expr:
-    return x ** Fraction(1, 2)
+    # Sympify so numeric literals stay in exact SymPy arithmetic (not float).
+    return S(x) ** Fraction(1, 2)
 
 
 def bracket(x: Expr) -> Expr:
     """
     The "Japanese bracket" notation.
     """
-    return sqrt(1 + abs(x) ** 2)
+    return sqrt(1 + abs(S(x)) ** 2)
 
 
 class LittlewoodPaley(BooleanFunction):

--- a/src/estimates/prooftree.py
+++ b/src/estimates/prooftree.py
@@ -32,6 +32,11 @@ class ProofTree:
 
     def use_tactic(self, tactic: Tactic) -> bool:
         """Apply a tactic to the proof state and create child nodes for each resulting proof state."""
+        # Do not re-apply tactics to nodes that already have a proof step; that
+        # would overwrite the tactic and append extra sorry children, reopening
+        # completed (or partially progressed) subgoals.
+        if self.tactic is not None:
+            return False
         proof_state_list = tactic.activate(self.proof_state)
         if len(proof_state_list) == 1 and proof_state_list[0].eq(self.proof_state):
             return False  # This tactic did nothing, so don't add a child node


### PR DESCRIPTION
## Summary
- `ProofTree.use_tactic`: refuse re-application on nodes that already have a tactic (was reopening completed subgoals).
- `littlewood_paley.sqrt` / `bracket`: sympify inputs so numeric literals stay exact (not float).
- `docs/linprog.md`: fix path to `src/estimates/linprog.py` and document `feasibility()` (removed nonexistent `verbose_feasibility`).

Branches: `fix/prooftree-guard-completed`, `fix/littlewood-paley-sympify`, `fix/linprog-docs-path-and-api`.

## Test plan
- [x] `bracket(0)` → SymPy `1`; `bracket(-3)` → `sqrt(10)`
- [x] completed ProofTree child rejects a second `use_tactic`
- [x] `pytest` still 23 pass / 1 fail (pre-existing Z3 counterexample issue; see #46)

Made with [Cursor](https://cursor.com)