### PR TITLE
fix: sympify Littlewood-Paley sqrt/bracket inputs

### DIFF
--- a/src/estimates/littlewood_paley.py
+++ b/src/estimates/littlewood_paley.py
@@ -1,5 +1,6 @@
 from fractions import Fraction
 
+from sympy import S
 from sympy.core.expr import Expr
 from sympy.logic.boolalg import BooleanFunction
 
@@ -9,14 +10,15 @@ from estimates.order_of_magnitude import Theta, asymp
 
 
 def sqrt(x: Expr) -> Expr:
-    return x ** Fraction(1, 2)
+    # Sympify so numeric literals stay in exact SymPy arithmetic (not float).
+    return S(x) ** Fraction(1, 2)
 
 
 def bracket(x: Expr) -> Expr:
     """
     The "Japanese bracket" notation.
     """
-    return sqrt(1 + abs(x) ** 2)
+    return sqrt(1 + abs(S(x)) ** 2)
 
 
 class LittlewoodPaley(BooleanFunction):


### PR DESCRIPTION
## Problem

In `src/estimates/littlewood_paley.py`, `sqrt(x)` computes `x ** Fraction(1, 2)` directly. When `x` is a plain Python int/float (rather than an already-sympified `Expr`), this evaluates using Python's built-in numeric `**`, which returns an inexact `float`:

```python
>>> from estimates.littlewood_paley import sqrt, bracket
>>> type(sqrt(2))
<class 'float'>
>>> sqrt(2)
1.4142135623730951
```

`bracket(x) = sqrt(1 + abs(x) ** 2)` inherits the same issue. This defeats the purpose of using sympy `Expr` objects for exact symbolic/order-of-magnitude reasoning elsewhere in the library (e.g. comparisons with `Theta`/`asymp` expect exact sympy expressions, not floats).

## Fix

Wrap the input in `sympy.S(...)` before exponentiation/absolute value so the arithmetic stays in exact sympy form:

```python
def sqrt(x: Expr) -> Expr:
    return S(x) ** Fraction(1, 2)

def bracket(x: Expr) -> Expr:
    return sqrt(1 + abs(S(x)) ** 2)
```

After the fix:
```python
>>> type(sqrt(2))
<class 'sympy.core.power.Pow'>
>>> sqrt(2)
sqrt(2)
>>> bracket(3)
sqrt(10)
```

## Verification

- Reproduced the bug on current `main` via `uv run python -c "..."` (shown above, returns `float`).
- Confirmed the fix resolves it on this branch (returns exact sympy `Pow`).
- `uv run pytest tests/ -k littlewood -q` passes (2 passed).
- Ran the full suite (`uv run pytest tests/ -q`): 1 pre-existing failure (`test_linarith_failure_example`, a z3 exception) reproduces identically on unmodified `upstream/main`, so it is unrelated to this change; all other 23 tests pass on both.