### PR TITLE
fix: correct Amgm.description to match GM ≤ AM

### DIFF
--- a/src/estimates/lemma.py
+++ b/src/estimates/lemma.py
@@ -104,7 +104,7 @@ class Amgm(Lemma):
         return "am_gm(" + ", ".join(str(x) for x in self.vars) + ")"
     
     label = "AM-GM Inequality"
-    description = "The arithmetic mean-geometric mean inequality, can be applied to expressions of the form `a**2 + b**2 + ... + z**2`."
+    description = "The arithmetic mean-geometric mean inequality (x₁⋯xₙ)^{1/n} ≤ (x₁+⋯+xₙ)/n. Requires nonnegative expressions."
     arguments = ["expressions"]
 
 


### PR DESCRIPTION
## Summary
- The web UI tooltip for AM-GM claimed it applied to sums of squares
- `Amgm.apply` implements the standard GM ≤ AM on nonnegative expressions
- Align the description with the lemma and with `docs/lemmas.md`

## Test plan
- [x] Diff shows only the description string
- [ ] Tooltip in the webapp reads as AM-GM on nonnegative expressions