### PR TITLE
Name Let/Set definitional hyps after the uniquified variable

### DIFF
--- a/src/estimates/subst.py
+++ b/src/estimates/subst.py
@@ -8,6 +8,16 @@ from estimates.simp import simp
 # Substitution tactics
 
 
+def fresh_var_and_def(state: ProofState, requested: str, expr: Basic) -> tuple[str, str, Basic, ProofState]:
+    """Allocate a fresh variable name and a matching `*_def` hypothesis name."""
+    newstate = state.copy()
+    name = newstate.new(requested)
+    var = new_var(typeof(expr), name)
+    newstate.hypotheses[name] = Type(var)
+    def_name = newstate.new(name + "_def")
+    return name, def_name, var, newstate
+
+
 class Let(Tactic):
     """
     A tactic to introduce a new variable, defined to equal a given expression.
@@ -28,12 +38,8 @@ class Let(Tactic):
             raise ValueError(
                 f"{self.expr!s} is not defined in the current proof state."
             )
-        newstate = state.copy()
-        name = newstate.new(self.name)
-        var = new_var(typeof(self.expr), name)
-        newstate.hypotheses[name] = Type(var)
+        name, def_name, var, newstate = fresh_var_and_def(state, self.name, self.expr)
         print(f"Letting {name} := {self.expr}.")
-        def_name = newstate.new(name + "_def")
         newstate.hypotheses[def_name] = Eq(var, self.expr)
         return [newstate]
 
@@ -64,10 +70,7 @@ class Set(Tactic):
             raise ValueError(
                 f"{self.expr!s} is not defined in the current proof state."
             )
-        newstate = state.copy()
-        name = newstate.new(self.name)
-        var = new_var(typeof(self.expr), name)
-        newstate.hypotheses[name] = Type(var)
+        name, def_name, var, newstate = fresh_var_and_def(state, self.name, self.expr)
         print(f"Setting {name} := {self.expr}.")
 
         for other_name, other_expr in state.hypotheses.items():
@@ -75,8 +78,6 @@ class Set(Tactic):
                 newstate.hypotheses[other_name] = other_expr.subs(self.expr, var)
 
         newstate.set_goal(state.goal.subs(self.expr, var))
-
-        def_name = newstate.new(name + "_def")
         newstate.hypotheses[def_name] = Eq(var, self.expr)
         return [newstate]
 

--- a/src/estimates/subst.py
+++ b/src/estimates/subst.py
@@ -11,6 +11,8 @@ from estimates.simp import simp
 class Let(Tactic):
     """
     A tactic to introduce a new variable, defined to equal a given expression.
+    The definitional hypothesis is named after the uniquified variable, e.g.
+    `y_def` or `x'_def` when `x` is already in use.
     """
 
     def __init__(self, name: str, expr: Basic) -> None:
@@ -26,12 +28,12 @@ class Let(Tactic):
             raise ValueError(
                 f"{self.expr!s} is not defined in the current proof state."
             )
-        name = state.new(self.name)
         newstate = state.copy()
+        name = newstate.new(self.name)
         var = new_var(typeof(self.expr), name)
         newstate.hypotheses[name] = Type(var)
         print(f"Letting {name} := {self.expr}.")
-        def_name = state.new(self.name + "_def")
+        def_name = newstate.new(name + "_def")
         newstate.hypotheses[def_name] = Eq(var, self.expr)
         return [newstate]
 
@@ -46,6 +48,7 @@ class Let(Tactic):
 class Set(Tactic):
     """
     A tactic to introduce a new variable, defined to equal a given expression, then substitute all instances of that expression with the variable.
+    The definitional hypothesis is named after the uniquified variable.
     """
 
     def __init__(self, name: str, expr: Basic) -> None:
@@ -61,8 +64,8 @@ class Set(Tactic):
             raise ValueError(
                 f"{self.expr!s} is not defined in the current proof state."
             )
-        name = state.new(self.name)
         newstate = state.copy()
+        name = newstate.new(self.name)
         var = new_var(typeof(self.expr), name)
         newstate.hypotheses[name] = Type(var)
         print(f"Setting {name} := {self.expr}.")
@@ -73,7 +76,7 @@ class Set(Tactic):
 
         newstate.set_goal(state.goal.subs(self.expr, var))
 
-        def_name = state.new(self.name + "_def")
+        def_name = newstate.new(name + "_def")
         newstate.hypotheses[def_name] = Eq(var, self.expr)
         return [newstate]
 

--- a/src/estimates/subst.py
+++ b/src/estimates/subst.py
@@ -47,7 +47,7 @@ class Let(Tactic):
         return f"let {self.name} := {self.expr}"
 
     label = "Let"
-    description = "Introduce a new variable, defined to equal a given expression."
+    description = "Introduce a new variable, defined to equal a given expression. The definitional hypothesis is named after the (possibly primed) variable."
     arguments = ["variables", "expressions"]
 
 
@@ -85,7 +85,7 @@ class Set(Tactic):
         return f"set {self.name} := {self.expr}"
 
     label = "Set"
-    description = "Introduce a new variable, defined to equal a given expression, then substitute all instances of that expression with the variable."
+    description = "Introduce a new variable, defined to equal a given expression, then substitute all instances of that expression with the variable. The definitional hypothesis is named after the (possibly primed) variable."
     arguments = ["variables", "expressions"]
 
 

--- a/tests/test_fresh_var_and_def.py
+++ b/tests/test_fresh_var_and_def.py
@@ -1,0 +1,23 @@
+from sympy import Symbol
+
+from estimates.basic import Type
+from estimates.proofstate import ProofState
+from estimates.subst import fresh_var_and_def
+
+
+def test_fresh_var_and_def_on_empty_state():
+    x = Symbol("x", positive=True, real=True)
+    state = ProofState(x > 0, {"x": Type(x)})
+    name, def_name, var, newstate = fresh_var_and_def(state, "y", x + 1)
+    assert name == "y"
+    assert def_name == "y_def"
+    assert name in newstate.hypotheses
+    assert def_name not in newstate.hypotheses  # caller fills the Eq
+
+
+def test_fresh_var_and_def_primes_taken_name():
+    x = Symbol("x", positive=True, real=True)
+    state = ProofState(x > 0, {"x": Type(x)})
+    name, def_name, var, newstate = fresh_var_and_def(state, "x", x + 1)
+    assert name == "x'"
+    assert def_name == "x'_def"

--- a/tests/test_let_set_def_names.py
+++ b/tests/test_let_set_def_names.py
@@ -1,0 +1,56 @@
+from sympy import Eq
+
+from estimates.basic import Type
+from estimates.proofassistant import ProofAssistant
+from estimates.subst import Let, Set
+
+
+def _names(p: ProofAssistant) -> dict:
+    return p.current_hypotheses()
+
+
+def test_let_pairs_def_with_fresh_name():
+    p = ProofAssistant()
+    x = p.var("pos_real", "x")
+    p.begin_proof(x > 0)
+    p.use(Let("x", x + 1))
+    hyps = _names(p)
+    assert "x'" in hyps
+    assert isinstance(hyps["x'"], Type)
+    assert "x'_def" in hyps
+    assert "x_def" not in hyps
+    assert hyps["x'_def"] == Eq(hyps["x'"].var(), x + 1)
+
+
+def test_set_pairs_def_with_fresh_name():
+    p = ProofAssistant()
+    x = p.var("pos_real", "x")
+    p.begin_proof(x > 0)
+    p.use(Set("x", x + 1))
+    hyps = _names(p)
+    assert "x'" in hyps
+    assert "x'_def" in hyps
+    assert "x_def" not in hyps
+
+
+def test_let_plain_name_still_uses_x_def():
+    p = ProofAssistant()
+    x = p.var("pos_real", "x")
+    p.begin_proof(x > 0)
+    p.use(Let("y", x + 1))
+    hyps = _names(p)
+    assert "y" in hyps
+    assert "y_def" in hyps
+    assert hyps["y_def"] == Eq(hyps["y"].var(), x + 1)
+
+
+def test_let_does_not_reuse_existing_def_name():
+    p = ProofAssistant()
+    x = p.var("pos_real", "x")
+    p.assume(x == x, "x_def")
+    p.begin_proof(x > 0)
+    p.use(Let("y", 2 * x))
+    hyps = _names(p)
+    assert "y" in hyps
+    assert "y_def" in hyps
+    assert hyps["x_def"] == (x == x)


### PR DESCRIPTION
## Summary
- Let/Set used state.new(requested+"_def"), so a collision on x made the variable x' but the definition hyp x_def
- fresh_var_and_def names the hyp after the uniquified variable (x'_def)

## Test plan
- `python -m pytest tests/test_let_set_def_names.py tests/test_fresh_var_and_def.py`


Made with [Cursor](https://cursor.com)