### PR TITLE
Pass use_sympy into recursive rsimp walks

### DIFF
--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -23,6 +23,7 @@ from estimates.bounded import is_fixed, is_bounded
 def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Basic:
     """
     Recursively simplifies the goal using a set of hypotheses.  If `use_sympy` is True, it uses sympy's simplifier on this node before simplifying subterms with the same flag.
+    """
 
     if use_sympy:  # Use sympy's simplifier.  Note that this may have unwanted behavior.
         goal = simplify(goal)
@@ -92,7 +93,8 @@ def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Bas
 
 def simp(goal: Basic, hypotheses:set[Basic] = set(), use_sympy = False) -> Basic:
     """
-    Simplifies the goal using the hypothesis.  If `use_sympy` is True, it uses sympy's simplifier.
+    Simplifies the goal using the hypothesis.  If `use_sympy` is True, it uses sympy's simplifier
+    and rsimp walks subterms with the same flag.
     """
 
     if isinstance(goal, Type):

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -22,7 +22,7 @@ from estimates.bounded import is_fixed, is_bounded
 
 def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Basic:
     """
-    Recursively simplifies the goal using a set of hypotheses.  If `use_sympy` is True, it uses sympy's simplifier."""
+    Recursively simplifies the goal using a set of hypotheses.  If `use_sympy` is True, it uses sympy's simplifier on this node before simplifying subterms with the same flag.
 
     if use_sympy:  # Use sympy's simplifier.  Note that this may have unwanted behavior.
         goal = simplify(goal)

--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -24,11 +24,11 @@ def rsimp(goal: Basic, hypotheses: set[Basic] = set(), use_sympy = False) -> Bas
     """
     Recursively simplifies the goal using a set of hypotheses.  If `use_sympy` is True, it uses sympy's simplifier."""
 
-    new_args = [rsimp(arg, hypotheses) for arg in goal.args]
-
     if use_sympy:  # Use sympy's simplifier.  Note that this may have unwanted behavior.
         goal = simplify(goal)
         hypotheses = {simplify(hyp) for hyp in hypotheses}
+
+    new_args = [rsimp(arg, hypotheses, use_sympy) for arg in goal.args]
 
     if goal in hypotheses:
         return true

--- a/tests/test_rsimp_use_sympy.py
+++ b/tests/test_rsimp_use_sympy.py
@@ -1,0 +1,20 @@
+from sympy import Add, Integer, Symbol, expand
+
+from estimates.simp import rsimp
+
+
+def test_rsimp_passes_use_sympy_into_subterms():
+    x = Symbol("x", real=True)
+    expr = (x + 1) * (x - 1) + 0
+    # Without the flag, the product is left as a Mul of expanded-looking factors.
+    plain = rsimp(expr, set(), False)
+    with_sympy = rsimp(expr, set(), True)
+    assert with_sympy == expand(expr)
+    assert plain != with_sympy or expand(expr) == expr
+
+
+def test_rsimp_nested_add_with_sympy():
+    x = Symbol("x", real=True)
+    expr = Add(x + 0, Integer(0), evaluate=False)
+    out = rsimp(expr, set(), True)
+    assert out == x

--- a/tests/test_rsimp_use_sympy.py
+++ b/tests/test_rsimp_use_sympy.py
@@ -18,3 +18,9 @@ def test_rsimp_nested_add_with_sympy():
     expr = Add(x + 0, Integer(0), evaluate=False)
     out = rsimp(expr, set(), True)
     assert out == x
+
+
+def test_rsimp_without_flag_keeps_structure():
+    x = Symbol("x", real=True)
+    expr = (x + 1) * (x - 1)
+    assert rsimp(expr, set(), False) == expr


### PR DESCRIPTION
## Summary
- rsimp used to simplify a node after already recursing without use_sympy, then rebuild from the unsimplified args
- it now simplifies the node first and walks subterms with the same flag

## Test plan
- `python -m pytest tests/test_rsimp_use_sympy.py`


Made with [Cursor](https://cursor.com)