### PR TITLE
Require symbolic evidence before promoting a variable to nonzero

### DIFF
--- a/src/estimates/simp.py
+++ b/src/estimates/simp.py
@@ -1,4 +1,4 @@
-from sympy import Basic, Eq, Max, Min, Not, false, simplify, true, Expr
+from sympy import Basic, Eq, Ne, Max, Min, Not, false, simplify, true, Expr
 from sympy.logic.boolalg import Boolean
 from sympy.core.relational import (
     GreaterThan,
@@ -322,7 +322,7 @@ class IsNonzero(Tactic):
             print(f"{name} is already a nonzero type.")
             return [state.copy()]
 
-        if not state.test(var != 0):
+        if not state.test(Ne(var, 0)):
             print(f"Cannot prove {name} is nonzero.")
             return [state.copy()]
 

--- a/tests/test_is_nonzero.py
+++ b/tests/test_is_nonzero.py
@@ -1,0 +1,39 @@
+from sympy import Eq, Ne
+from estimates.basic import Type, new_var
+from estimates.proofstate import ProofState
+from estimates.simp import IsNonzero
+
+
+def test_nonzero_requires_evidence():
+    for kind in ("real", "rat", "int"):
+        x = new_var(kind, "x")
+        for extra in ({}, {"zero": Eq(x, 0)}):
+            state = ProofState(Ne(x, 0), {"x": Type(x), **extra})
+            before = state.copy()
+            result = IsNonzero("x").activate(state)
+            assert len(result) == 1
+            assert result[0].eq(before)
+            assert state.eq(before)
+
+
+def test_nonzero_uses_symbolic_hypothesis():
+    for kind in ("real", "rat", "int"):
+        x = new_var(kind, "x")
+        for argument in ("x", x):
+            state = ProofState(Ne(x, 0), {"x": Type(x), "h": Ne(x, 0)})
+            before = state.copy()
+            assert IsNonzero(argument).activate(state) == []
+            assert state.eq(before)
+
+
+def test_nonzero_preserves_unsolved_goal_and_substitutes_hypotheses():
+    x = new_var("real", "x")
+    state = ProofState(Eq(x**2, 2), {"x": Type(x), "h": Ne(x, 0)})
+    before = state.copy()
+    result = IsNonzero("x").activate(state)
+    assert len(result) == 1
+    nonzero_x = result[0].get_var("x")
+    assert nonzero_x.is_nonzero is True
+    assert result[0].goal == Eq(nonzero_x**2, 2)
+    assert result[0].hypotheses["h"] == True
+    assert state.eq(before)


### PR DESCRIPTION
`IsNonzero("x")` currently solves `Ne(x, 0)` for an arbitrary declared real variable with no hypothesis. Python's `x != 0` is structural inequality and evaluates to `True` before the proof checker sees it; this also permits promotion when `Eq(x, 0)` is a hypothesis.

Pass SymPy's `Ne(x, 0)` to the checker. Regression tests cover absent and contradictory evidence for real/rational/integer declarations, valid evidence through both tactic argument forms, substitution into an unsolved goal, and preservation of the input proof state.

Validation: `PYTHONPATH=src python -m pytest tests -q`: 26 passed; the existing `test_linarith_failure_example` fails identically on unchanged upstream (23 passed, 1 failed there). All 3 new regression tests pass; the original unsound proof reproduces on upstream.

This defect was reproduced during a code audit; no existing issue report is claimed.
