### PR TITLE
Keep proof mode active when earlier or nested goals remain

### DIFF
--- a/src/estimates/prooftree.py
+++ b/src/estimates/prooftree.py
@@ -137,6 +137,7 @@ class ProofTree:
         before = None
         after = None
         found_target = False
+        first_sorry = None
         for child in self.children:
             found, last_before, first_after = child.find_sorry(target)
             if found:
@@ -145,12 +146,14 @@ class ProofTree:
                     before = last_before
                 after = first_after
             else:
+                if first_sorry is None:
+                    first_sorry = first_after
                 if found_target:
                     if after is None:
                         after = first_after
-                else:
+                elif last_before is not None:
                     before = last_before
-        return (found_target, before, after)
+        return (found_target, before, after if found_target else first_sorry)
 
     def count_sorries(self, target: ProofTree) -> tuple[bool, int, int]:
         """
@@ -158,15 +161,7 @@ class ProofTree:
         Also returns whether the target was found in the tree.
         """
         if self == target:
-            before = 0
-            after = 0
-            for child in self.children:
-                found, before_count, after_count = child.count_sorries(target)
-                if found:
-                    after += after_count
-                else:
-                    before += before_count
-            return True, before, after
+            return True, 0, sum(child.num_sorries() for child in self.children)
         if self.tactic is None:
             return False, 1, 1
         before = 0
@@ -183,7 +178,7 @@ class ProofTree:
                     after += after_count
                 else:
                     before += before_count
-        return (found_target, before, after)
+        return (found_target, before, after if found_target else before)
 
     def __str__(self) -> str:
         return self.rstr_join()

--- a/tests/test_proof_navigation.py
+++ b/tests/test_proof_navigation.py
@@ -1,0 +1,71 @@
+from sympy import And, S
+
+from estimates.proofassistant import ProofAssistant
+from estimates.proofstate import ProofState
+from estimates.prooftree import ProofTree
+from estimates.propositional_tactics import SplitGoal
+from estimates.simp import SimpAll
+
+
+def branch(parent):
+    parent.tactic = SplitGoal()
+    return parent.add_sorry(ProofState(S.true))
+
+
+def test_previous_goal_survives_a_completed_sibling():
+    root = ProofTree(ProofState(S.true))
+    first = branch(root)
+    middle = branch(root)
+    middle.tactic = SimpAll()
+    target = branch(root)
+    assert root.find_sorry(target) == (True, first, None)
+
+
+def test_next_goal_descends_into_a_nested_branch():
+    root = ProofTree(ProofState(S.true))
+    target = branch(root)
+    nested = branch(root)
+    next_goal = branch(nested)
+    assert root.find_sorry(target) == (True, None, next_goal)
+    assert root.find_sorry(root) == (True, None, target)
+    target.tactic = SimpAll()
+    assert root.find_sorry(root) == (True, None, next_goal)
+
+
+def test_solving_later_goals_keeps_the_first_goal_active():
+    assistant = ProofAssistant()
+    x, y, z = assistant.vars('real', 'x', 'y', 'z')
+    for variable in (x, y, z):
+        assistant.assume(variable > 0)
+    assistant.begin_proof(And(x > 0, y > 0, z > 0))
+    assistant.use(SplitGoal())
+    root = assistant.proof_tree
+    assert len(root.children) == 3
+    assistant.set_current_node(root.children[1])
+    assistant.use(SimpAll())
+    assistant.use(SimpAll())
+    assert root.num_sorries() == 1
+    assert assistant.mode == 'tactic'
+    assert assistant.current_node is root.children[0]
+    assistant.use(SimpAll())
+    assert root.num_sorries() == 0
+    assert assistant.mode == 'assumption'
+
+
+def test_counts_include_nested_goals_after_the_target():
+    root = ProofTree(ProofState(S.true))
+    target = branch(root)
+    nested = branch(root)
+    branch(nested)
+    branch(nested)
+    assert root.count_sorries(target) == (True, 0, 2)
+    assert root.count_sorries(root) == (True, 0, 3)
+
+
+def test_missing_target_reports_both_edges_of_the_subtree():
+    root = ProofTree(ProofState(S.true))
+    first = branch(root)
+    last = branch(root)
+    missing = ProofTree(ProofState(S.true))
+    assert root.find_sorry(missing) == (False, last, first)
+    assert root.count_sorries(missing) == (False, 2, 2)


### PR DESCRIPTION
With three goals, solving the second and then the third can exit tactic mode while the first is still unresolved. `find_sorry` forgets the earlier open goal when it crosses a completed sibling. It also loses the first open goal inside a nested subtree, and `count_sorries` omits nested goals after the current node.

Preserve the first and last open goals when the target is outside a subtree, and keep the previous goal when a completed sibling has no replacement. Count all descendant goals after an internal target. A regression uses the real `ProofAssistant`, `SplitGoal`, and `SimpAll` flow and verifies that tactic mode continues until the first goal is solved.

Validation: five focused tests pass. The complete suite reports 28 passed and one failure; current upstream has the identical `test_linarith_failure_example` Z3 symbolic-Boolean failure (23 passed, one failed). That existing counterexample issue is separate from navigation and is already covered by an open PR. `git diff --check` passes.
